### PR TITLE
Allow "main" as default branch

### DIFF
--- a/lib/repository_report.rb
+++ b/lib/repository_report.rb
@@ -1,7 +1,7 @@
 class RepositoryReport < GithubGraphQlClient
   attr_reader :organization, :repo_name, :team
 
-  MASTER = "master"
+  MAIN_BRANCHES = ["main", "master"] # We are changing to use "main" but many repos still use "master" as default branch
   ADMIN = "admin"
   PASS = "PASS"
   FAIL = "FAIL"
@@ -117,7 +117,7 @@ class RepositoryReport < GithubGraphQlClient
     requiring_branch_protection_rules do |rules|
 
       rules
-        .select { |edge| edge.dig("node", "pattern") == MASTER }
+        .select { |edge| MAIN_BRANCHES.include?(edge.dig("node", "pattern")) }
         .any?
     end
   end

--- a/lib/repository_report.rb
+++ b/lib/repository_report.rb
@@ -45,7 +45,7 @@ class RepositoryReport < GithubGraphQlClient
 
   def all_checks_result
     @all_checks_result ||= {
-      has_master_branch_protection: has_master_branch_protection?,
+      has_main_branch_protection: has_main_branch_protection?,
       requires_approving_reviews: has_branch_protection_property?("requiresApprovingReviews"),
       requires_code_owner_reviews: has_branch_protection_property?("requiresCodeOwnerReviews"),
       administrators_require_review: has_branch_protection_property?("isAdminEnforced"),
@@ -113,7 +113,7 @@ class RepositoryReport < GithubGraphQlClient
     @rules ||= repo_data.dig("data", "repository", "branchProtectionRules", "edges")
   end
 
-  def has_master_branch_protection?
+  def has_main_branch_protection?
     requiring_branch_protection_rules do |rules|
 
       rules

--- a/makefile
+++ b/makefile
@@ -1,4 +1,4 @@
-VERSION := 1.1.0
+VERSION := 1.2.0
 
 cloud-platform-repository-checker.gemspec: Rakefile.template bin/* lib/*
 	(export VERSION=$(VERSION); cat Rakefile.template | envsubst > Rakefile)

--- a/spec/fixtures/good-repo-main.json
+++ b/spec/fixtures/good-repo-main.json
@@ -1,0 +1,25 @@
+{
+  "data": {
+    "repository": {
+      "name": "cloud-platform-infrastructure",
+      "url": "https://github.com/ministryofjustice/cloud-platform-infrastructure",
+      "owner": {
+        "login": "ministryofjustice"
+      },
+      "branchProtectionRules": {
+        "edges": [
+          {
+            "node": {
+              "pattern": "main",
+              "requiresApprovingReviews": true,
+              "requiresCodeOwnerReviews": true,
+              "isAdminEnforced": true,
+              "dismissesStaleReviews": true,
+              "requiresStrictStatusChecks": true
+            }
+          }
+        ]
+      }
+    }
+  }
+}

--- a/spec/repository_report_spec.rb
+++ b/spec/repository_report_spec.rb
@@ -26,17 +26,19 @@ describe RepositoryReport do
   end
 
   context "when repository is correctly configured" do
-    let(:repo_data) { JSON.parse(File.read("spec/fixtures/good-repo.json")) }
+    ["spec/fixtures/good-repo.json", "spec/fixtures/good-repo-main.json"].each do |fixture|
+      let(:repo_data) { JSON.parse(File.read(fixture)) }
 
-    it "passes" do
-      result = report.report
-      expect(result[:status]).to eq("PASS")
-    end
+      it "passes" do
+        result = report.report
+        expect(result[:status]).to eq("PASS")
+      end
 
-    it "passes checks" do
-      checks.each do |check|
-        result = report.report[:report]
-        expect(result[check]).to be(true)
+      it "passes checks" do
+        checks.each do |check|
+          result = report.report[:report]
+          expect(result[check]).to be(true)
+        end
       end
     end
   end

--- a/spec/repository_report_spec.rb
+++ b/spec/repository_report_spec.rb
@@ -8,7 +8,7 @@ describe RepositoryReport do
 
   let(:checks) {
     [
-      :has_master_branch_protection,
+      :has_main_branch_protection,
       :requires_approving_reviews,
       :requires_code_owner_reviews,
       :administrators_require_review,


### PR DESCRIPTION
This change will accept repos which protect either "main" or "master" branches.