### PR TITLE
Enable specific repos to break the rules

### DIFF
--- a/bin/cloud-platform-repository-checker
+++ b/bin/cloud-platform-repository-checker
@@ -16,8 +16,15 @@ require_relative "../lib/repository_report"
 
 ############################################################
 
+# Exceptions are repos which are allowed to break the rules.
+# e.g. a repo to which compiled html files for a github pages
+# site can't implement branch protection, but we don't want it
+# to show up as an error
+exceptions = ENV["REPO_EXCEPTIONS"].to_s.split(" ")
+
 params = {
   organization: ENV.fetch("ORGANIZATION"),
+  exceptions: exceptions,
   regexp: Regexp.new(ENV.fetch("REGEXP")),
   team: ENV.fetch("TEAM"),
   github_token: ENV.fetch("GITHUB_TOKEN")

--- a/lib/repository_report.rb
+++ b/lib/repository_report.rb
@@ -1,5 +1,5 @@
 class RepositoryReport < GithubGraphQlClient
-  attr_reader :organization, :repo_name, :team
+  attr_reader :organization, :exceptions, :repo_name, :team
 
   MAIN_BRANCH = "main"
   ADMIN = "admin"
@@ -8,6 +8,7 @@ class RepositoryReport < GithubGraphQlClient
 
   def initialize(params)
     @organization = params.fetch(:organization)
+    @exceptions = params.fetch(:exceptions) # repos which are allowed to break the rules
     @repo_name = params.fetch(:repo_name)
     @team = params.fetch(:team)
     super(params)
@@ -41,7 +42,11 @@ class RepositoryReport < GithubGraphQlClient
   end
 
   def status
-    all_checks_result.values.all? ? PASS : FAIL
+    if exceptions.include?(repo_name)
+      PASS
+    else
+      all_checks_result.values.all? ? PASS : FAIL
+    end
   end
 
   def all_checks_result

--- a/makefile
+++ b/makefile
@@ -1,4 +1,4 @@
-VERSION := 1.3.0
+VERSION := 1.4.0
 
 cloud-platform-repository-checker.gemspec: Rakefile.template bin/* lib/*
 	(export VERSION=$(VERSION); cat Rakefile.template | envsubst > Rakefile)

--- a/spec/repository_report_spec.rb
+++ b/spec/repository_report_spec.rb
@@ -1,7 +1,11 @@
 describe RepositoryReport do
+  let(:exceptions) { [] }
+  let(:repo_name) { "cloud-platform-infrastructure" }
+
   let(:params) { {
     organization: "ministryofjustice",
-    repo_name: "cloud-platform-infrastructure",
+    exceptions: exceptions,
+    repo_name: repo_name,
     team: "WebOps",
     github_token: "dummytoken"
   } }
@@ -58,6 +62,25 @@ describe RepositoryReport do
       checks.each do |check|
         result = report.report[:report]
         expect(result[check]).to be(false)
+      end
+    end
+
+    context "when repo is an allowed exception" do
+      let(:repo_name) { "cloud-platform-repository-checker" }
+      let(:exceptions) { [ repo_name ] }
+
+      it "passes" do
+        result = report.report
+        expect(result[:status]).to eq("PASS")
+      end
+
+      # The individual checks still fail, we just override the
+      # overall PASS/FAIL status of the repo.
+      it "fails checks" do
+        checks.each do |check|
+          result = report.report[:report]
+          expect(result[check]).to be(false)
+        end
       end
     end
   end


### PR DESCRIPTION
Some repositories can't implement branch
protection, or have to specify "gh-pages" as the
default branch.

This change allows a list of repos to break rules
but still "PASS" overall, so they won't show up
as errors.