### PR TITLE
Remove the requirement for strict status checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,21 @@
 # cloud-platform-repository-checker
+
 Checks all Cloud Platform repositories for compliance
+
+## Updating
+
+This code is published as a [ruby gem].
+
+To publish a new version:
+
+* Authenticate to `rubygems.org` as `ministryofjustice` (credentials are in LastPass)
+* Update the `VERSION` value in the `makefile`
+* Run `make publish`
+
+This will repackage the gem using the latest code, and push a new release to
+rubygems.org
+
+> Please remember to keep the unit tests in `spec` up to date wrt. your code
+> changes.
+
+[ruby gem]: https://rubygems.org/gems/cloud-platform-repository-checker

--- a/Rakefile.template
+++ b/Rakefile.template
@@ -16,7 +16,7 @@ spec = Gem::Specification.new do |s|
   # Change these as appropriate
   s.name              = "cloud-platform-repository-checker"
   s.version           = "${VERSION}"
-  s.summary           = "What this thing does"
+  s.summary           = "Check that ministryofjustice/cloud-platform-* github repositories comply with our standards"
   s.author            = "David Salgado"
   s.email             = "platforms@digital.justice.gov.uk"
   s.homepage          = "https://github.com/ministryofjustice/cloud-platform"

--- a/lib/repository_report.rb
+++ b/lib/repository_report.rb
@@ -57,7 +57,6 @@ class RepositoryReport < GithubGraphQlClient
       requires_code_owner_reviews: has_branch_protection_property?("requiresCodeOwnerReviews"),
       administrators_require_review: has_branch_protection_property?("isAdminEnforced"),
       dismisses_stale_reviews: has_branch_protection_property?("dismissesStaleReviews"),
-      requires_strict_status_checks: has_branch_protection_property?("requiresStrictStatusChecks"),
       team_is_admin: is_team_admin?,
     }
   end

--- a/makefile
+++ b/makefile
@@ -1,4 +1,4 @@
-VERSION := 1.4.0
+VERSION := 1.4.1
 
 cloud-platform-repository-checker.gemspec: Rakefile.template bin/* lib/*
 	(export VERSION=$(VERSION); cat Rakefile.template | envsubst > Rakefile)

--- a/spec/fixtures/bad-repo-master.json
+++ b/spec/fixtures/bad-repo-master.json
@@ -17,8 +17,7 @@
               "requiresApprovingReviews": true,
               "requiresCodeOwnerReviews": true,
               "isAdminEnforced": true,
-              "dismissesStaleReviews": true,
-              "requiresStrictStatusChecks": true
+              "dismissesStaleReviews": true
             }
           }
         ]

--- a/spec/fixtures/good-repo.json
+++ b/spec/fixtures/good-repo.json
@@ -17,8 +17,7 @@
               "requiresApprovingReviews": true,
               "requiresCodeOwnerReviews": true,
               "isAdminEnforced": true,
-              "dismissesStaleReviews": true,
-              "requiresStrictStatusChecks": true
+              "dismissesStaleReviews": true
             }
           }
         ]

--- a/spec/repository_report_spec.rb
+++ b/spec/repository_report_spec.rb
@@ -18,7 +18,6 @@ describe RepositoryReport do
       :requires_code_owner_reviews,
       :administrators_require_review,
       :dismisses_stale_reviews,
-      :requires_strict_status_checks,
       :team_is_admin,
     ]
   }


### PR DESCRIPTION
This check requires that a branch is up to date wrt. the default branch
before a PR can be merged. This doesn't apply for, e.g. the cloud-platform-
environments repository, or any other repo. where multiple, non-overlapping
changes are likely to be made.

Arguably, this shouldn't be one of our standard requirements for our
repositories, so this change removes it altogether.